### PR TITLE
manifest: add new omap4 hardware repo for current device support

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -421,6 +421,7 @@
   <project path="hardware/ril" name="CyanogenMod/android_hardware_ril" groups="pdk" />
   <project path="hardware/ril-caf" name="CyanogenMod/android_hardware_ril" groups="pdk" revision="cm-12.0-caf" />
   <project path="hardware/samsung_slsi/exynos5" name="CyanogenMod/android_hardware_samsung_slsi_exynos5" />
+  <project path="hardware/ti/omap4" name="CyanogenMod/android_hardware_ti_omap4" />
   <project path="hardware/ti/omap4-aah" name="platform/hardware/ti/omap4-aah" groups="omap4-aah" remote="aosp" />
   <project path="hardware/ti/omap4xxx" name="CyanogenMod/android_hardware_ti_omap4xxx" />
   <project path="hardware/ti/wlan" name="CyanogenMod/android_hardware_ti_wlan" />


### PR DESCRIPTION
This repo is for devices using a kernel based on omapzoom 3.0.31 release.

Includes many updates for versions of Android which were not originally
supported by TI (beyond JBMR0):
- camera compatibilty updates
- DOMX updates and removal of duplicated OMX headers
- PVR-source is DDK 1.9@2291151
- and more

Change-Id: Ic6958751ce18e0140751a28eb1e13270d8e688a1
Signed-off-by: Hashcode <hashcode0f@gmail.com>