### PR TITLE
Fix: Add the missing library: libtruezip from lineageos into sudamod

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -242,6 +242,7 @@
   <project path="external/libphonenumber" name="platform/external/libphonenumber" groups="pdk" remote="aosp" />
   <project path="external/libpng" name="platform/external/libpng" groups="pdk" remote="aosp" />
   <project path="external/libselinux" name="LineageOS/android_external_libselinux" groups="pdk" />
+  <project path="external/libtruezip" name="LineageOS/android_external_libtruezip" groups="pdk" />
   <project path="external/libunwind" name="platform/external/libunwind" groups="pdk" remote="aosp" />
   <project path="external/libunwind_llvm" name="platform/external/libunwind_llvm" groups="pdk" remote="aosp" />
   <project path="external/libusb" name="platform/external/libusb" groups="pdk-cw-fs,pdk" remote="aosp" />


### PR DESCRIPTION
 libtruezip which is required by the CMFileManager, does not have this library,
 and the compiler stops accidentally and prompts for the error, now fix the problem.

Change-Id: I54b814b8357a30961f1385a81264740db4c0b06e
Signed-off-by: gesangtome <gesangtome@foxmail.com>