### PR TITLE
Unspecified branch name caused synchronization error

### DIFF
--- a/snippets/lineage.xml
+++ b/snippets/lineage.xml
@@ -24,11 +24,11 @@
   <project path="external/vim" name="LineageOS/android_external_vim" />
   <!--<project path="external/yaffs2" name="LineageOS/android_external_yaffs2" />-->
   <project path="external/zip" name="LineageOS/android_external_zip" />
+  <project path="hardware/cyanogen" name="LineageOS/android_hardware_cyanogen" revision="lineage-15.0" />
   <project path="hardware/lineage/interfaces" name="LineageOS/android_hardware_lineage_interfaces" >
     <copyfile dest="hardware/lineage/Android.bp" src="Android.bp"/>
   </project>
   <project path="hardware/lineage/lineagehw" name="LineageOS/android_hardware_lineage_lineagehw" />
-  <project path="hardware/cyanogen" name="LineageOS/android_hardware_cyanogen" />
   <!--<project path="hardware/ti/omap4" name="LineageOS/android_hardware_ti_omap4" />-->
   <!--<project path="hardware/ti/wlan" name="LineageOS/android_hardware_ti_wlan" />-->
   <!--<project path="hardware/ti/wpan" name="LineageOS/android_hardware_ti_wpan" />-->


### PR DESCRIPTION
In the upstream branch, the missing branch name is lineage-15.1
After specifying the branch name, the error can be resolved

Change-Id: I4fe1c3d17cf2063f5f86db99a4416f6f4e17bb27
Signed-off-by: Flowertome <gesangtome@foxmail.com>